### PR TITLE
Deploy nfs server along with minikube

### DIFF
--- a/scripts/utilities/minikube.sh
+++ b/scripts/utilities/minikube.sh
@@ -14,7 +14,7 @@ function install_shared_storage_server() {
 function start_minikube () {
   info "Starting Minikube ..."
   "${__zimagi_binary_dir}"/minikube start \
-    --driver=${MINIKUBE_DRIVER:-docker} \
+    --driver=${MINIKUBE_DRIVER} \
     --cpus=${MINIKUBE_CPUS} \
     --kubernetes-version=${MINIKUBE_KUBERNETES_VERSION} \
     --container-runtime=${MINIKUBE_CONTAINER_RUNTIME}

--- a/scripts/utilities/minikube.sh
+++ b/scripts/utilities/minikube.sh
@@ -3,13 +3,23 @@
 # MiniKube Utilities
 #
 
+
+function install_shared_storage_server() {
+  "${__zimagi_binary_dir}"/helm repo add nfs-ganesha-server-and-external-provisioner https://kubernetes-sigs.github.io/nfs-ganesha-server-and-external-provisioner/
+  "${__zimagi_binary_dir}"/helm upgrade --install \
+    nfs-server-provisioner \
+    nfs-ganesha-server-and-external-provisioner/nfs-server-provisioner
+}
+
 function start_minikube () {
   info "Starting Minikube ..."
   "${__zimagi_binary_dir}"/minikube start \
-    --driver=${MINIKUBE_DRIVER} \
+    --driver=${MINIKUBE_DRIVER:-docker} \
     --cpus=${MINIKUBE_CPUS} \
     --kubernetes-version=${MINIKUBE_KUBERNETES_VERSION} \
     --container-runtime=${MINIKUBE_CONTAINER_RUNTIME}
+  info "Installing Shared Storage Server ..."
+  install_shared_storage_server
 }
 
 function stop_minikube () {

--- a/scripts/utilities/minikube.sh
+++ b/scripts/utilities/minikube.sh
@@ -18,6 +18,7 @@ function start_minikube () {
     --cpus=${MINIKUBE_CPUS} \
     --kubernetes-version=${MINIKUBE_KUBERNETES_VERSION} \
     --container-runtime=${MINIKUBE_CONTAINER_RUNTIME}
+
   info "Installing Shared Storage Server ..."
   install_shared_storage_server
 }

--- a/scripts/utilities/values.py
+++ b/scripts/utilities/values.py
@@ -24,6 +24,9 @@ helm_values['redis'] = {
         'password': os.environ['ZIMAGI_REDIS_PASSWORD']
     }
 }
+helm_values['persistenceFlavour'] = {
+    'minikube': True
+}
 
 # Generate environment variables
 env_values = []


### PR DESCRIPTION
After minikube is started a nfs server is deployed to leverage shared storage
for zimagi cluster in local development area.

Signed-off-by: Erik Jagyugya <jagyugyaerik@gmail.com>